### PR TITLE
add `!default` flag to variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ Bemify can can of course also be used inside any scope:
 ### Configuration Options
 
 bemify uses some configuration variables where to adjust the block-element and the state separator, as well as the state prefix.
-To overwrite bemify's config with your own configuration file, import your configuration AFTER importing bemify, BUT BEFORE calling the mixins.
+To overwrite bemify's config with your own configuration file, just import your variables before using one of the mixins.
 
+    @import "your-variables";
     @import "bemify";
-    @import "my_config";
 
     @include block('my-block') {
         …

--- a/sass/_bemify.scss
+++ b/sass/_bemify.scss
@@ -14,16 +14,16 @@
 //    .block__element.is-active {}
 // Set to false to output single, non-combined state modifiers:
 //    .block__element--is-active {}
-$combined-state-selectors:    true;
+$combined-state-selectors: true !default;
 
 // .block[separator]element:
-$element-separator:              "__";
+$element-separator:        "__" !default;
 
 // .block[separator]modifier:
-$modifier-separator:             "--";
+$modifier-separator:       "--" !default;
 
 // The default prefix for state modifier selectors, will be combined with $modifier-separator:
-$state-prefix:                "is";
+$state-prefix:             "is" !default;
 
 
 


### PR DESCRIPTION
Using the `!default` flag only sets the variables if they aren't already set, so the variables doesn't need to be overwritten, but instead can be used anywhere by the user.
